### PR TITLE
XPS 13 Revived

### DIFF
--- a/unencrypted.md
+++ b/unencrypted.md
@@ -66,7 +66,7 @@ Device             Start       End   Sectors   Size Type
 
 As reported by `gdisk /dev/nvme0n1`
 ```
-The protective MBR's 0xEE partition is oversized! Auto-repairing
+The protective MBR's 0xEE partition is oversized! Auto-repairing.
 
 Partition table scan:
   MBR: protective

--- a/xps13.md
+++ b/xps13.md
@@ -66,7 +66,7 @@ Device             Start       End   Sectors   Size Type
 
 As reported by `gdisk /dev/nvme0n1`
 ```
-The protective MBR's 0xEE partition is oversized! Auto-repairing
+The protective MBR's 0xEE partition is oversized! Auto-repairing.
 
 Partition table scan:
   MBR: protective

--- a/xps13.md
+++ b/xps13.md
@@ -60,10 +60,8 @@ Disk identifier: DACEF394-88D5-415B-8C97-1CDBB7516C0A
 Device             Start       End   Sectors   Size Type
 /dev/nvme0n1p1      2048   1026047   1024000   500M EFI System
 /dev/nvme0n1p2   1026048   1288191    262144   128M Microsoft reserved
-/dev/nvme0n1p3   1288192 473675775 472387584 225.3G Microsoft basic data
-/dev/nvme0n1p4 473675776 474597375    921600   450M Windows recovery environment
-/dev/nvme0n1p5 474597376 497907711  23310336  11.1G Windows recovery environment
-/dev/nvme0n1p6 497909760 500117503   2207744   1.1G Windows recovery environment
+/dev/nvme0n1p3   1288192 499179519 497891328 237.4G Microsoft basic data
+/dev/nvme0n1p4 499179520 500115455    935936   457M Windows recovery environment
 ```
 
 As reported by `gdisk /dev/nvme0n1`
@@ -81,7 +79,7 @@ Found valid GPT with protective MBR; using GPT.
 Command (? for help): p
 Disk /dev/nvme0n1: 500118192 sectors, 238.5 GiB
 Logical sector size: 512 bytes
-Disk identifier (GUID): DACEF394-88D5-415B-8C97-1CDBB7516C0A
+Disk identifier (GUID): 6F07E9A0-9365-4227-939C-380E0D6B74F1
 Partition table holds up to 128 entries
 First usable sector is 34, last usable sector is 500118158
 Partitions will be aligned on 2048-sector boundaries
@@ -90,10 +88,8 @@ Total free space is 4717 sectors (2.3 MiB)
 Number  Start (sector)    End (sector)  Size      Code  Name
    1            2048         1026047   500.0 MiB  EF00  EFI system partition
    2         1026048         1288191   128.0 MiB  0C01  Microsoft reserved ...
-   3         1288192       473675775   225.3 GiB  0700  Basic data partition
-   4       473675776       474597375   450.0 MiB  2700
-   5       474597376       497907711   11.1 GiB   2700
-   6       497909760       500117503   1.1 GiB    2700
+   3         1288192       499179519   237.4 GiB  0700  Basic data partition
+   4       499179520       500115455   457.0 MiB  2700
 ```
 
 ## Partitions: after
@@ -134,7 +130,7 @@ p
 
 Disk /dev/nvme0n1: 500118192 sectors, 238.5 GiB
 Logical sector size: 512 bytes
-Disk identifier (GUID): 33DEB725-2DF3-4673-A182-B5FCB48D92FA
+Disk identifier (GUID): B53933BA-EC89-4053-902E-F3F066C8026F
 Partition table holds up to 128 entries
 First usable sector is 34, last usable sector is 500118158
 Partitions will be aligned on 2048-sector boundaries
@@ -142,7 +138,7 @@ Total free space is 2014 sectors (1007.0 KiB)
 
 Number  Start (sector)    End (sector)  Size      Code  Name
    1            2048         1026047   500.0 MiB  EF00  EFI System
-   2         1026048       500117503   238.0 GiB  8E00  Linux LVM
+   2         1026048       500118158   238.0 GiB  8E00  Linux LVM
 ```
 Write changes
 ```

--- a/xps13.md
+++ b/xps13.md
@@ -1,7 +1,7 @@
 ## Download installation CD image
 
 - [NixOS downloads page](https://nixos.org/nixos/download.html)
- - [Minimal installation CD, 64-bit Intel/AMD](https://d3g5gsiof5omrk.cloudfront.net/nixos/17.09/nixos-17.09.2075.ac35504065/nixos-minimal-17.09.2075.ac35504065-x86_64-linux.iso)
+ - [Minimal installation CD, 64-bit Intel/AMD](https://d3g5gsiof5omrk.cloudfront.net/nixos/17.09/nixos-17.09.2731.92d088e891e/nixos-minimal-17.09.2731.92d088e891e-x86_64-linux.iso)
 
 ## Format USB drive (on a mac)
 
@@ -20,7 +20,7 @@
 diskutil list
 diskutil unmountDisk /dev/disk2
 sudo dd bs=4m \
-        if=/Users/ivan/Downloads/nixos-minimal-17.09.2075.ac35504065-x86_64-linux.iso \
+        if=/Users/ivan/Downloads/nixos-minimal-17.09.2731.92d088e891e-x86_64-linux.iso \
         of=/dev/disk2
 ```
 When macOS prompts about unreadable disk, select "Eject".

--- a/xps13.md
+++ b/xps13.md
@@ -381,7 +381,7 @@ nano /etc/nixos/configuration.nix
 ```
 environment.systemPackages = with pkgs; [
   mkpasswd
-  vimHugeX
+  vim
 ];
 ```
 

--- a/xps13.md
+++ b/xps13.md
@@ -29,7 +29,9 @@ When macOS prompts about unreadable disk, select "Eject".
 http://topics-cdn.dell.com/pdf/xps-13-9360-laptop_setup%20guide_en-us.pdf
 
 ## BIOS
-- power on Dell XPS 13
+- turn off Dell XPS 13
+- insert USB
+- turn on Dell XPS 13
 - tap F2 repeatedly at Dell logo to enter BIOS
 - disable Secure Boot
   - Settings > Secure Boot > Secure Boot Enable : Disabled


### PR DESCRIPTION
I sent the XPS 13 back to Dell for service, to deal with a keyboard debounce issue. The issue is still present, though much less prominent. I've tried other XPS machines and confirmed the same issue on them, so an exchange doesn't make much sense. I'm going to try this [kernel module workaround](https://github.com/nylen/i8042-debounce), but first, reinstall NixOS.